### PR TITLE
Remove unused dependencies from provider-bamboo/go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,6 @@ github.com/yunarta/terraform-api-transport v1.0.0 h1:7Zp9FiZm4QG8hIPj/odCVjaqXfR
 github.com/yunarta/terraform-api-transport v1.0.0/go.mod h1:KCRrG4fBwMob0+dhyhgZm6ZEsJTk3BmAwjcVlSeq4I0=
 github.com/yunarta/terraform-atlassian-api-client v1.3.0 h1:UKlRUGkH1YzvAY2HqvmoyYwPq35KXTsRmHw4IMKi5M8=
 github.com/yunarta/terraform-atlassian-api-client v1.3.0/go.mod h1:R3gu4RFcs85QBjruvBCQLt3IpMXXl8y6NYmfA976sBM=
-github.com/yunarta/terraform-provider-commons v1.0.0 h1:Zna6HFHe7iOM5LIsJLYCzSOK1VpfZmkTKsVqdSvwMTs=
-github.com/yunarta/terraform-provider-commons v1.0.0/go.mod h1:cMM6yuj5kv5ugou9T9uOwLARlwlI77OfAJXDXzxPqVM=
 github.com/yunarta/terraform-provider-commons v1.0.1 h1:xiygGeHQZVxd0GDBu+8O7jqNwbsSzZf+twLRiNWlTmo=
 github.com/yunarta/terraform-provider-commons v1.0.1/go.mod h1:gXzBv5F0F/52m46qPp8hzYrdQSG/VScTnJXf4muldXg=
 github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA=


### PR DESCRIPTION
Deleted the references to the old version of "terraform-provider-commons" (v1.0.0) from provider-bamboo/go.sum file. This change is required to clean up unused dependencies and maintain up-to-date source code files. The project now contains only the latest versions of the dependencies.