### PR TITLE
Add checks for existing bamboo repositories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.21.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.0
-	github.com/yunarta/terraform-atlassian-api-client v1.3.5
+	github.com/yunarta/terraform-atlassian-api-client v1.3.7
 	github.com/yunarta/terraform-provider-commons v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.0 h1:7Zp9FiZm4QG8hIPj/odCVjaqXfRzH2M7uVrip+SFWwI=
 github.com/yunarta/terraform-api-transport v1.0.0/go.mod h1:KCRrG4fBwMob0+dhyhgZm6ZEsJTk3BmAwjcVlSeq4I0=
-github.com/yunarta/terraform-atlassian-api-client v1.3.5 h1:CL8JG4xM0AH57SzzQVl3SoY30Nlxa3rPigDnUEtoAk0=
-github.com/yunarta/terraform-atlassian-api-client v1.3.5/go.mod h1:R3gu4RFcs85QBjruvBCQLt3IpMXXl8y6NYmfA976sBM=
+github.com/yunarta/terraform-atlassian-api-client v1.3.7 h1:0CDgyngW/sjB9IsJCO7yJmJYxQLzUjTBGKcmM25BaVA=
+github.com/yunarta/terraform-atlassian-api-client v1.3.7/go.mod h1:R3gu4RFcs85QBjruvBCQLt3IpMXXl8y6NYmfA976sBM=
 github.com/yunarta/terraform-provider-commons v1.0.1 h1:xiygGeHQZVxd0GDBu+8O7jqNwbsSzZf+twLRiNWlTmo=
 github.com/yunarta/terraform-provider-commons v1.0.1/go.mod h1:gXzBv5F0F/52m46qPp8hzYrdQSG/VScTnJXf4muldXg=
 golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=


### PR DESCRIPTION
Introduced checks in bamboo linked repository and bamboo project linked repository to prevent creation if a repository with the same name already exists. This enhances error handling by providing clear messages when trying to create already existing resources in Bamboo. Refactored "repository" variable declaration for more uniform and cleaner code.
