### PR TITLE
Update terraform-atlassian-api-client to v1.3.8 and enable repository…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.21.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.0
-	github.com/yunarta/terraform-atlassian-api-client v1.3.7
+	github.com/yunarta/terraform-atlassian-api-client v1.3.8
 	github.com/yunarta/terraform-provider-commons v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.0 h1:7Zp9FiZm4QG8hIPj/odCVjaqXfRzH2M7uVrip+SFWwI=
 github.com/yunarta/terraform-api-transport v1.0.0/go.mod h1:KCRrG4fBwMob0+dhyhgZm6ZEsJTk3BmAwjcVlSeq4I0=
-github.com/yunarta/terraform-atlassian-api-client v1.3.7 h1:0CDgyngW/sjB9IsJCO7yJmJYxQLzUjTBGKcmM25BaVA=
-github.com/yunarta/terraform-atlassian-api-client v1.3.7/go.mod h1:R3gu4RFcs85QBjruvBCQLt3IpMXXl8y6NYmfA976sBM=
+github.com/yunarta/terraform-atlassian-api-client v1.3.8 h1:rDFF3w0UE1YUFiRZwR08y0forDVqizJWPGCL499EsiQ=
+github.com/yunarta/terraform-atlassian-api-client v1.3.8/go.mod h1:R3gu4RFcs85QBjruvBCQLt3IpMXXl8y6NYmfA976sBM=
 github.com/yunarta/terraform-provider-commons v1.0.1 h1:xiygGeHQZVxd0GDBu+8O7jqNwbsSzZf+twLRiNWlTmo=
 github.com/yunarta/terraform-provider-commons v1.0.1/go.mod h1:gXzBv5F0F/52m46qPp8hzYrdQSG/VScTnJXf4muldXg=
 golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=

--- a/provider/resource_bamboo_linked_repository.go
+++ b/provider/resource_bamboo_linked_repository.go
@@ -137,6 +137,13 @@ func (receiver *LinkedRepositoryResource) Create(ctx context.Context, request re
 		return
 	}
 
+	if plan.RssEnabled.ValueBool() {
+		err = receiver.client.RepositoryService().ScanCI(repositoryId)
+		if util.TestError(&response.Diagnostics, err, "Failed to execute scan repository") {
+			return
+		}
+	}
+
 	repository = &bamboo.Repository{
 		ID:         repositoryId,
 		Name:       plan.Name.ValueString(),
@@ -222,6 +229,13 @@ func (receiver *LinkedRepositoryResource) Update(ctx context.Context, request re
 	err = receiver.client.RepositoryService().EnableCI(repository.ID, plan.RssEnabled.ValueBool())
 	if util.TestError(&response.Diagnostics, err, errorFailedToUpdateRepository) {
 		return
+	}
+
+	if plan.RssEnabled.ValueBool() {
+		err = receiver.client.RepositoryService().ScanCI(repository.ID)
+		if util.TestError(&response.Diagnostics, err, "Failed to execute scan repository") {
+			return
+		}
 	}
 
 	if !plan.Project.Equal(state.Project) || !plan.Slug.Equal(state.Slug) {

--- a/provider/resource_bamboo_project_linked_repository.go
+++ b/provider/resource_bamboo_project_linked_repository.go
@@ -160,6 +160,13 @@ func (receiver *ProjectLinkedRepositoryResource) Create(ctx context.Context, req
 		return
 	}
 
+	if plan.RssEnabled.ValueBool() {
+		err = receiver.client.RepositoryService().ScanCI(repository.ID)
+		if util.TestError(&response.Diagnostics, err, "Failed to execute scan repository") {
+			return
+		}
+	}
+
 	repository = &bamboo.Repository{
 		ID:         repositoryId,
 		Name:       plan.Name.ValueString(),
@@ -245,6 +252,13 @@ func (receiver *ProjectLinkedRepositoryResource) Update(ctx context.Context, req
 	err = receiver.client.RepositoryService().EnableCI(repository.ID, plan.RssEnabled.ValueBool())
 	if util.TestError(&response.Diagnostics, err, errorFailedToUpdateRepository) {
 		return
+	}
+
+	if plan.RssEnabled.ValueBool() {
+		err = receiver.client.RepositoryService().ScanCI(repository.ID)
+		if util.TestError(&response.Diagnostics, err, "Failed to execute scan repository") {
+			return
+		}
 	}
 
 	if !plan.Project.Equal(state.Project) || !plan.Slug.Equal(state.Slug) {


### PR DESCRIPTION
… scanning

This commit updates the terraform-atlassian-api-client dependency to version 1.3.8. Apart from this, new code has been added to trigger a CI scan within Bamboo's RepositoryService if the RssEnabled flag is set to true. This improves control over CI operations and ensures timely discovery of common code issues.