### PR TITLE
Fix repository ID reference in RepositoryService

### DIFF
--- a/provider/resource_bamboo_project_linked_repository.go
+++ b/provider/resource_bamboo_project_linked_repository.go
@@ -173,7 +173,7 @@ func (receiver *ProjectLinkedRepositoryResource) Create(ctx context.Context, req
 	}
 
 	if plan.RssEnabled.ValueBool() {
-		err = receiver.client.RepositoryService().ScanCI(repository.ID)
+		err = receiver.client.RepositoryService().ScanCI(repositoryId)
 		if util.TestError(&response.Diagnostics, err, "Failed to execute scan repository") {
 			return
 		}


### PR DESCRIPTION
Fixed incorrect repository ID reference in the RepositoryService function call within the bamboo Terraform provider. The ID is now correctly retrieved from the 'repositoryId' variable instead of the non-existent 'repository.ID' member.