### PR TITLE
Update GoReleaser action to v6.0.0 in Terraform providers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           args: release --clean
         env:


### PR DESCRIPTION
This commit updates the version of the GoReleaser action used in the release workflows of the Bitbucket and Bamboo Terraform providers. This change upgrades the action version from v5.0.0 to v6.0.0, likely bringing in new features and improvements.