### PR TITLE
Add PlanResource for Bamboo Provider

### DIFF
--- a/provider/plan_model.go
+++ b/provider/plan_model.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/yunarta/terraform-atlassian-api-client/bamboo"
+)
+
+type PlanModel struct {
+	RetainOnDelete types.Bool   `tfsdk:"retain_on_delete"`
+	Id             types.Int64  `tfsdk:"id"`
+	ProjectKey     types.String `tfsdk:"project"`
+	Key            types.String `tfsdk:"key"`
+	Name           types.String `tfsdk:"name"`
+}
+
+//var _ ProjectPermissionInterface = &ProjectModel{}
+//
+//func (d ProjectModel) getAssignment(ctx context.Context) (Assignments, diag.Diagnostics) {
+//	var assignments Assignments = make([]Assignment, 0)
+//
+//	diags := d.Assignments.ElementsAs(ctx, &assignments, true)
+//	return assignments, diags
+//}
+//
+//func (d ProjectModel) getProjectKey(ctx context.Context) string {
+//	return d.Key.ValueString()
+//}
+
+func NewPlanModel(plan PlanModel, bambooPlan *bamboo.Plan) *PlanModel {
+	//id, _ := strconv.Atoi(bambooPlan.Id)
+	return &PlanModel{
+		RetainOnDelete: plan.RetainOnDelete,
+		Id:             types.Int64Value(bambooPlan.Id),
+		ProjectKey:     types.StringValue(bambooPlan.ProjectKey),
+		Key:            types.StringValue(bambooPlan.ShortKey),
+		Name:           plan.Name,
+	}
+}

--- a/provider/resource_bamboo_plan.go
+++ b/provider/resource_bamboo_plan.go
@@ -1,0 +1,221 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/yunarta/terraform-atlassian-api-client/bamboo"
+	"github.com/yunarta/terraform-provider-commons/util"
+	"strings"
+)
+
+var (
+	_ resource.Resource                = &PlanResource{}
+	_ resource.ResourceWithConfigure   = &PlanResource{}
+	_ resource.ResourceWithImportState = &PlanResource{}
+	_ ProjectPermissionsReceiver       = &PlanResource{}
+	_ ConfigurableReceiver             = &PlanResource{}
+)
+
+func NewPlanResource() resource.Resource {
+	return &PlanResource{}
+}
+
+type PlanResource struct {
+	config BambooProviderConfig
+	client *bamboo.Client
+}
+
+func (receiver *PlanResource) setConfig(config BambooProviderConfig, client *bamboo.Client) {
+	receiver.config = config
+	receiver.client = client
+}
+
+func (receiver *PlanResource) getClient() *bamboo.Client {
+	return receiver.client
+}
+
+func (receiver *PlanResource) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = request.ProviderTypeName + "_plan"
+}
+
+func (receiver *PlanResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		MarkdownDescription: `This resource define project plan.
+
+The priority block has a priority that defines the final assigned permissions of the user or group.`,
+		Attributes: map[string]schema.Attribute{
+			"retain_on_delete": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Default value is `true`, and if the value set to `false` when the resource destroyed, the project will be removed.",
+			},
+			"id": schema.Int64Attribute{
+				Computed:            true,
+				MarkdownDescription: "Plan id.",
+			},
+			"project": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				MarkdownDescription: "Project key.",
+			},
+			"key": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				MarkdownDescription: "Plan key.",
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Project name.",
+			},
+		},
+	}
+}
+
+func (receiver *PlanResource) Configure(ctx context.Context, request resource.ConfigureRequest, response *resource.ConfigureResponse) {
+	ConfigureResource(receiver, ctx, request, response)
+}
+
+func (receiver *PlanResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var (
+		diags diag.Diagnostics
+
+		plan PlanModel
+	)
+
+	diags = request.Plan.Get(ctx, &plan)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+
+	bambooPlan, err := receiver.client.PlanService().Create(bamboo.CreatePlan{
+		PlanKey:    plan.Key.ValueString(),
+		Name:       plan.Name.ValueString(),
+		ProjectKey: plan.ProjectKey.ValueString(),
+	})
+	if util.TestError(&response.Diagnostics, err, "Failed to create project") {
+		return
+	}
+
+	//computation, diags := CreateProjectAssignments(ctx, receiver, plan)
+	//if util.TestDiagnostic(&response.Diagnostics, diags) {
+	//	return
+	//}
+
+	planModel := NewPlanModel(plan, bambooPlan)
+
+	diags = response.State.Set(ctx, planModel)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+}
+
+func (receiver *PlanResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var (
+		diags diag.Diagnostics
+
+		state PlanModel
+	)
+
+	diags = request.State.Get(ctx, &state)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+
+	bambooPlan, err := receiver.client.PlanService().Read(fmt.Sprintf("%s-%s", state.ProjectKey.ValueString(), state.Key.ValueString()))
+	if util.TestError(&response.Diagnostics, err, "Failed to create plan") {
+		return
+	}
+
+	//computation, diags := ComputeProjectAssignments(ctx, receiver, state)
+	//if util.TestDiagnostic(&response.Diagnostics, diags) {
+	//	return
+	//}
+
+	planModel := NewPlanModel(state, bambooPlan)
+
+	diags = response.State.Set(ctx, planModel)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+}
+
+func (receiver *PlanResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var (
+		diags diag.Diagnostics
+
+		plan, state PlanModel
+	)
+
+	diags = request.Plan.Get(ctx, &plan)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+
+	diags = request.State.Get(ctx, &state)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+
+	bambooPlan, err := receiver.client.PlanService().Read(fmt.Sprintf("%s-%s", state.ProjectKey.ValueString(), state.Key.ValueString()))
+	if util.TestError(&response.Diagnostics, err, "Failed to read plan") {
+		return
+	}
+
+	//forceUpdate := !plan.AssignmentVersion.Equal(state.AssignmentVersion)
+	//computation, diags := UpdateProjectAssignments(ctx, receiver, plan, state, forceUpdate)
+	//if util.TestDiagnostic(&response.Diagnostics, diags) {
+	//	return
+	//}
+
+	planModel := NewPlanModel(plan, bambooPlan)
+
+	diags = response.State.Set(ctx, planModel)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+}
+
+func (receiver *PlanResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var (
+		diags diag.Diagnostics
+		state PlanModel
+	)
+
+	diags = request.State.Get(ctx, &state)
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+
+	if !state.RetainOnDelete.ValueBool() {
+		err := receiver.client.PlanService().Delete(fmt.Sprintf("%s-%s", state.ProjectKey.ValueString(), state.Key.ValueString()))
+		if util.TestError(&response.Diagnostics, err, "Failed to delete plan") {
+			return
+		}
+	}
+
+	response.State.RemoveResource(ctx)
+}
+
+func (receiver *PlanResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	slug := strings.Split(request.ID, "-")
+	diags := response.State.Set(ctx, &PlanModel{
+		ProjectKey: types.StringValue(slug[0]),
+		Key:        types.StringValue(slug[1]),
+		Name:       types.StringNull(),
+	})
+	if util.TestDiagnostic(&response.Diagnostics, diags) {
+		return
+	}
+}


### PR DESCRIPTION
A new resource 'PlanResource' is introduced for the Bamboo provider in Terraform. This resource is capable of creating, reading, updating, and deleting plans. It also supports schema import operation for easy management of existing plans. I've also added a 'PlanModel'. This helps to map the Bamboo plan structure and supports different operations on the plan resource.