### PR TITLE
Add functionality to find available users and groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.1
-	github.com/yunarta/terraform-atlassian-api-client v1.3.12
+	github.com/yunarta/terraform-atlassian-api-client v1.3.13
 	github.com/yunarta/terraform-provider-commons v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.1 h1:WzxCUGs8UJcCYB09ErLLXtu8NGzKIoCfWNlLQTjnYA4=
 github.com/yunarta/terraform-api-transport v1.0.1/go.mod h1:sYdlgKir9SBUVv3GO/m5m7MtJ5o9FK/n4yRpQKmFvjM=
-github.com/yunarta/terraform-atlassian-api-client v1.3.12 h1:rB3afTmlBRZVQnhV9xb6cXf9g6FvV7AXCmuP4Abf3M0=
-github.com/yunarta/terraform-atlassian-api-client v1.3.12/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
+github.com/yunarta/terraform-atlassian-api-client v1.3.13 h1:Qw62vzMKh6zyZvK6MChJ3bFLNtFUeth7QoPP+XNHsPU=
+github.com/yunarta/terraform-atlassian-api-client v1.3.13/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
 github.com/yunarta/terraform-provider-commons v1.0.1 h1:xiygGeHQZVxd0GDBu+8O7jqNwbsSzZf+twLRiNWlTmo=
 github.com/yunarta/terraform-provider-commons v1.0.1/go.mod h1:gXzBv5F0F/52m46qPp8hzYrdQSG/VScTnJXf4muldXg=
 github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8=

--- a/provider/deployment_permissions.go
+++ b/provider/deployment_permissions.go
@@ -33,6 +33,12 @@ func CreateDeploymentAssignments(ctx context.Context, receiver DeploymentPermiss
 
 	return ApplyNewAssignmentSet(ctx, receiver.getClient().UserService(),
 		*assignmentOrder,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().DeploymentService().FindAvailableUser(deploymentId, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().DeploymentService().FindAvailableGroup(deploymentId, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().DeploymentService().UpdateUserPermissions(deploymentId, user, requestedPermissions)
 		},
@@ -94,6 +100,12 @@ func UpdateDeploymentAssignments(ctx context.Context, receiver DeploymentPermiss
 		*inStateAssignmentOrder,
 		*plannedAssignmentOrder,
 		forceUpdate,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().DeploymentService().FindAvailableUser(deploymentId, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().DeploymentService().FindAvailableGroup(deploymentId, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().DeploymentService().UpdateUserPermissions(deploymentId, user, requestedPermissions)
 		},
@@ -122,6 +134,12 @@ func DeleteDeploymentAssignments(ctx context.Context, receiver DeploymentPermiss
 	}
 
 	return RemoveAssignment(ctx, assignedPermissions, assignmentOrder,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().DeploymentService().FindAvailableUser(deploymentId, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().DeploymentService().FindAvailableGroup(deploymentId, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().DeploymentService().UpdateUserPermissions(deploymentId, user, requestedPermissions)
 		},

--- a/provider/linked_repository_permissions.go
+++ b/provider/linked_repository_permissions.go
@@ -32,6 +32,12 @@ func CreateLinkedRepositoryAssignments(ctx context.Context, receiver LinkedRepos
 
 	return ApplyNewAssignmentSet(ctx, receiver.getClient().UserService(),
 		*assignmentOrder,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().RepositoryService().FindAvailableUser(deploymentId, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().RepositoryService().FindAvailableGroup(deploymentId, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().RepositoryService().UpdateUserPermissions(deploymentId, user, requestedPermissions)
 		},
@@ -93,6 +99,12 @@ func UpdateLinkedRepositoryAssignments(ctx context.Context, receiver LinkedRepos
 		*inStateAssignmentOrder,
 		*plannedAssignmentOrder,
 		forceUpdate,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().RepositoryService().FindAvailableUser(deploymentId, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().RepositoryService().FindAvailableGroup(deploymentId, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().RepositoryService().UpdateUserPermissions(deploymentId, user, requestedPermissions)
 		},
@@ -121,6 +133,12 @@ func DeleteLinkedRepositoryAssignments(ctx context.Context, receiver LinkedRepos
 	}
 
 	return RemoveAssignment(ctx, assignedPermissions, assignmentOrder,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().RepositoryService().FindAvailableUser(deploymentId, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().RepositoryService().FindAvailableGroup(deploymentId, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().RepositoryService().UpdateUserPermissions(deploymentId, user, requestedPermissions)
 		},

--- a/provider/project_permission.go
+++ b/provider/project_permission.go
@@ -33,6 +33,12 @@ func CreateProjectAssignments(ctx context.Context, receiver ProjectPermissionsRe
 
 	return ApplyNewAssignmentSet(ctx, receiver.getClient().UserService(),
 		*assignmentOrder,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().ProjectService().FindAvailableUser(projectKey, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().ProjectService().FindAvailableGroup(projectKey, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().ProjectService().UpdateUserPermissions(projectKey, user, requestedPermissions)
 		},
@@ -94,6 +100,12 @@ func UpdateProjectAssignments(ctx context.Context, receiver ProjectPermissionsRe
 		*inStateAssignmentOrder,
 		*plannedAssignmentOrder,
 		forceUpdate,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().ProjectService().FindAvailableUser(projectKey, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().ProjectService().FindAvailableGroup(projectKey, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().ProjectService().UpdateUserPermissions(projectKey, user, requestedPermissions)
 		},
@@ -122,6 +134,12 @@ func DeleteProjectAssignments(ctx context.Context, receiver ProjectPermissionsRe
 	}
 
 	return RemoveAssignment(ctx, assignedPermissions, assignmentOrder,
+		func(user string) (*bamboo.UserPermission, error) {
+			return receiver.getClient().ProjectService().FindAvailableUser(projectKey, user)
+		},
+		func(group string) (*bamboo.GroupPermission, error) {
+			return receiver.getClient().ProjectService().FindAvailableGroup(projectKey, group)
+		},
 		func(user string, requestedPermissions []string) error {
 			return receiver.getClient().ProjectService().UpdateUserPermissions(projectKey, user, requestedPermissions)
 		},


### PR DESCRIPTION
This update adds a functionality to find available users and groups in repository, deployment, and project permissions. These new functions are used within the ApplyNewAssignmentSet, UpdateAssignment, and RemoveAssignment methods where the assignment orders are processed. This change will improve permission handling across the entire Terraform Bamboo provider.