### PR TITLE
Update terraform-provider-commons to v1.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.1
 	github.com/yunarta/terraform-atlassian-api-client v1.3.13
-	github.com/yunarta/terraform-provider-commons v1.0.2
+	github.com/yunarta/terraform-provider-commons v1.0.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/yunarta/terraform-api-transport v1.0.1 h1:WzxCUGs8UJcCYB09ErLLXtu8NGz
 github.com/yunarta/terraform-api-transport v1.0.1/go.mod h1:sYdlgKir9SBUVv3GO/m5m7MtJ5o9FK/n4yRpQKmFvjM=
 github.com/yunarta/terraform-atlassian-api-client v1.3.13 h1:Qw62vzMKh6zyZvK6MChJ3bFLNtFUeth7QoPP+XNHsPU=
 github.com/yunarta/terraform-atlassian-api-client v1.3.13/go.mod h1:QOj00CmhhXF+6kb8RBxEULIBEaZe0Bv+xMFmFHCHUIA=
-github.com/yunarta/terraform-provider-commons v1.0.2 h1:Mvae6Tx0syaRLh4MWfnP4sTp/oM+GEauhyuQM5+QWuk=
-github.com/yunarta/terraform-provider-commons v1.0.2/go.mod h1:8jL2esDNbF7MBfmE2gbrs45NSYnDk8XfRtpkpjxgXNU=
+github.com/yunarta/terraform-provider-commons v1.0.3 h1:+eHAfpObrOr3WKvGhZzZAYsPphiMmZOiF1pHhF82lOQ=
+github.com/yunarta/terraform-provider-commons v1.0.3/go.mod h1:8jL2esDNbF7MBfmE2gbrs45NSYnDk8XfRtpkpjxgXNU=
 github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8=
 github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 go.abhg.dev/goldmark/frontmatter v0.2.0 h1:P8kPG0YkL12+aYk2yU3xHv4tcXzeVnN+gU0tJ5JnxRw=


### PR DESCRIPTION
The 'terraform-provider-commons' has been updated from version v1.0.2 to version v1.0.3 in the 'go.mod' and 'go.sum' files. This update aims to enhance the handling of attribute changes with better precision. It now includes a 'createSlug' modifier in 'resource_bitbucket_repository.go' that triggers resource recreation in Terraform when the repository name is altered.