### PR TITLE
Update terraform-atlassian-api-client to v1.3.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.2
-	github.com/yunarta/terraform-atlassian-api-client v1.3.20
+	github.com/yunarta/terraform-atlassian-api-client v1.3.22
 	github.com/yunarta/terraform-provider-commons v1.0.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/yunarta/golang-quality-of-life-pack v1.0.0 h1:T0xwfFnD61x6Nz9ej+tRWK6
 github.com/yunarta/golang-quality-of-life-pack v1.0.0/go.mod h1:Qw+9tWyqPJxxHLyuxCo5xCNwmfG/TMOt8Vkfq0bl9TU=
 github.com/yunarta/terraform-api-transport v1.0.2 h1:uJ3+gAblwPWc4dVGD8ku7X4wLfUzi+pCC+dLS54JdiU=
 github.com/yunarta/terraform-api-transport v1.0.2/go.mod h1:uQshZ/gKlszLfamYY+y+4pAnxnOtzg6XC2zn63h8ZT4=
-github.com/yunarta/terraform-atlassian-api-client v1.3.20 h1:EQLX++IgPcIRJizZ5cDm6+nVrw3AGLD2koRj45l/lIE=
-github.com/yunarta/terraform-atlassian-api-client v1.3.20/go.mod h1:uu8we0EQNUX9WdZReegMzN/jEANZUW7m42WZhYj7rOc=
+github.com/yunarta/terraform-atlassian-api-client v1.3.22 h1:cfyBuAPUxwv+O8G8FL0OOJUzM+VcMJ5PnMMLBNr2j0A=
+github.com/yunarta/terraform-atlassian-api-client v1.3.22/go.mod h1:uu8we0EQNUX9WdZReegMzN/jEANZUW7m42WZhYj7rOc=
 github.com/yunarta/terraform-provider-commons v1.0.3 h1:+eHAfpObrOr3WKvGhZzZAYsPphiMmZOiF1pHhF82lOQ=
 github.com/yunarta/terraform-provider-commons v1.0.3/go.mod h1:8jL2esDNbF7MBfmE2gbrs45NSYnDk8XfRtpkpjxgXNU=
 github.com/zclconf/go-cty v1.15.0 h1:tTCRWxsexYUmtt/wVxgDClUe+uQusuI443uL6e+5sXQ=


### PR DESCRIPTION
Bump dependency from v1.3.20 to v1.3.22 in go.mod and go.sum. This ensures compatibility with the latest updates and fixes provided in the library.