### PR TITLE
Set `state.ID` for linked repositories and fix variable naming in per…

### DIFF
--- a/provider/project_linked_repository_permissions.go
+++ b/provider/project_linked_repository_permissions.go
@@ -58,8 +58,8 @@ func ComputeProjectLinkedRepositoryAssignments(ctx context.Context, receiver Pro
 		return nil, diags
 	}
 
-	deploymentId := state.getLinkedRepositoryId(ctx)
-	assignedPermissions, err := receiver.getClient().RepositoryService().ReadPermissions(deploymentId)
+	repositoryId := state.getLinkedRepositoryId(ctx)
+	assignedPermissions, err := receiver.getClient().RepositoryService().ReadPermissions(repositoryId)
 	if err != nil {
 		return nil, []diag.Diagnostic{diag.NewErrorDiagnostic("Failed to read deployment permissions", err.Error())}
 	}

--- a/provider/resource_bamboo_linked_repository.go
+++ b/provider/resource_bamboo_linked_repository.go
@@ -207,6 +207,8 @@ func (receiver *LinkedRepositoryResource) Read(ctx context.Context, request reso
 		return
 	}
 
+	state.ID = types.StringValue(fmt.Sprintf("%d", repository.ID))
+
 	computation, diags := ComputeProjectLinkedRepositoryAssignments(ctx, receiver, state)
 	if util.TestDiagnostic(&response.Diagnostics, diags) {
 		return

--- a/provider/resource_bamboo_project_linked_repository.go
+++ b/provider/resource_bamboo_project_linked_repository.go
@@ -230,6 +230,8 @@ func (receiver *ProjectLinkedRepositoryResource) Read(ctx context.Context, reque
 		return
 	}
 
+	state.ID = types.StringValue(fmt.Sprintf("%d", repository.ID))
+
 	computation, diags := ComputeProjectLinkedRepositoryAssignments(ctx, receiver, state)
 	if util.TestDiagnostic(&response.Diagnostics, diags) {
 		return


### PR DESCRIPTION
…missions.